### PR TITLE
[multi-chat] fix: trust all proxies.

### DIFF
--- a/src/multi-chat/app/Http/Middleware/TrustProxies.php
+++ b/src/multi-chat/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = "*";
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
The original setting will cause the front end to only generate http:// links, and requests for these resource files will be blocked by the browser.

![圖片](https://github.com/kuwaai/genai-os/assets/7872696/0a47fa11-98ca-40b3-a5bd-9dd409545a4e)

Even if the environment variable has been set, it will be ignored by Laravel.

![圖片](https://github.com/kuwaai/genai-os/assets/7872696/bd09e340-ceca-4177-baa5-fcb9af377355)

After this setting, Kuwa works well under https, but I am not good at PHP. Please re-evaluate whether this modification is appropriate.