### PR TITLE
[kernel] fix: Chat timeout 120s

### DIFF
--- a/src/kernel/src/kuwa/kernel/routes/chat.py
+++ b/src/kernel/src/kuwa/kernel/routes/chat.py
@@ -41,7 +41,7 @@ def completions_backend(form: dict, headers: dict, dest:list):
 
     llm_name = form.get("name")
     try:
-        response = requests.post(dest[0], headers=headers, data=form, stream=True, timeout=120)
+        response = requests.post(dest[0], headers=headers, data=form, stream=True, timeout=5000) # must build.bat again
         def event_stream(dest, response):
             dest[1] = "BUSY"
             try:


### PR DESCRIPTION
Extend the timeout from 120s to 5000s.
fix the [issue](https://github.com/kuwaai/genai-os/issues/23).
