### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/multi-chat/Dockerfile
+++ b/docker/multi-chat/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli as build
+FROM php:8.1-cli AS build
 
 # Install nodejs and composer
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - &&\


### PR DESCRIPTION
To remove the WARN message that complain "FromAsCasing: 'as' and 'FROM' keywords' casing do not match"