### PR TITLE
[win] fix: update model path of Whisper-Base-En

### DIFF
--- a/windows/src/version_patch/qnn/windows/executors/whisper_onnx/run.bat
+++ b/windows/src/version_patch/qnn/windows/executors/whisper_onnx/run.bat
@@ -6,5 +6,5 @@ pushd ..\..\..\src\multi-chat
 php artisan model:config ".model:qnn/qualcomm/whisper" "Whisper @NPU" --order=130001 --image "..\..\windows\executors\whisper_onnx\whisper.png"
 popd
 pushd ..\..\..\src\executor\speech_recognition\
-start /b "" "python" main.py "--access_code" ".model:qnn/qualcomm/whisper" "--model" "base" "--use_onnx" "--encoder_path" "hf://qualcomm/Whisper-Base-En?WhisperEncoderInf.onnx" "--decoder_path" "hf://qualcomm/Whisper-Base-En?WhisperDecoderInf.onnx"  "--log" "debug"
+start /b "" "python" main.py "--access_code" ".model:qnn/qualcomm/whisper" "--model" "base" "--use_onnx" "--encoder_path" "hf://qualcomm/Whisper-Base-En?Whisper-Base-En_WhisperEncoderInf.onnx" "--decoder_path" "hf://qualcomm/Whisper-Base-En?Whisper-Base-En_WhisperDecoderInf.onnx"  "--log" "debug"
 popd


### PR DESCRIPTION
The path of both encoder and decoder in qualcomm/Whisper-Base-En have been changed last week.
Reference: https://huggingface.co/qualcomm/Whisper-Base-En